### PR TITLE
Store AniList OAuth tokens in Redis [skip preview]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,12 @@ SESSION_SECRET=...           # any long random string
 
 Login uses **`GET /api/auth/login`** (server OAuth + session cookie).
 
-**Not used:** `DATABASE_URL`, `VITE_ANILIST_CLIENT_ID` — persistence is `node-persist` (`.persist-storage/`) for AniList OAuth tokens; login is fully server-side.
+**Not used:** `DATABASE_URL`, `VITE_ANILIST_CLIENT_ID` — AniList OAuth tokens are stored server-side (Redis in production, `node-persist` locally); login is fully server-side.
 
 **Sessions:**
 
 - Local dev: in-memory sessions by default (no Redis required).
-- Production: set **`REDIS_URL`** (Railway Redis add-on) so login sessions survive deploys/restarts.
+- Production: set **`REDIS_URL`** (Railway Redis add-on) so login sessions **and AniList tokens** survive deploys/restarts.
 - Optional **`SESSION_MAX_AGE_MS`** — default ~364 days (slightly under AniList’s 1-year access token).
 
 See **`docs/adr/001-passport-session-auth.md`** for the full auth architecture decision record.

--- a/PRODUCTION_CHECKLIST.md
+++ b/PRODUCTION_CHECKLIST.md
@@ -36,6 +36,16 @@
 - [ ] Session cookie is HttpOnly and secure in production
 - [ ] Rate limiting is active on `/api/` routes
 
+## Decommission Render (legacy)
+
+Production runs on **Railway** only. If Render still posts failed PR deployment checks:
+
+1. [Render Dashboard](https://dashboard.render.com/) → open the linked **AniListCal** web service
+2. **Settings** → disconnect the GitHub repo (or delete the service entirely)
+3. Optional: remove the Render GitHub App from [GitHub repo settings → Integrations](https://github.com/birdwell/AniListCal/settings/installations)
+
+`render.yaml` and deploy scripts were removed in commit `799fe79`; any remaining deploys come from the Render dashboard integration, not this repo.
+
 ## Optional follow-ups
 
 - [ ] Set up uptime monitoring on `/api/health`

--- a/PRODUCTION_CHECKLIST.md
+++ b/PRODUCTION_CHECKLIST.md
@@ -6,7 +6,7 @@
 - [ ] Configure AniList OAuth credentials for production
 - [ ] Register production redirect URI: `https://your-domain.com/api/auth/callback`
 - [ ] Set `FRONTEND_URL` and `BACKEND_CALLBACK_URL` to your public domain
-- [ ] Add Redis and set `REDIS_URL` on the app service (sessions survive restarts)
+- [ ] Add Redis and set `REDIS_URL` on the app service (sessions and AniList tokens survive restarts/deploys)
 - [ ] Set `NODE_ENV=production`
 - [ ] Do **not** set `PORT` on Railway (platform injects it)
 
@@ -28,7 +28,7 @@
 - [ ] Full login → callback → home flow works in a real browser
 - [ ] Logout clears the session
 - [ ] GraphQL proxy works for authenticated users (`POST /api/anilist/proxy`)
-- [ ] Session survives a redeploy (with Redis configured)
+- [ ] Session and AniList API access survive a redeploy (requires `REDIS_URL`)
 
 ## Security
 
@@ -38,7 +38,6 @@
 
 ## Optional follow-ups
 
-- [ ] Mount persistent storage for `.persist-storage/` if you want AniList tokens to survive container disk wipes
 - [ ] Set up uptime monitoring on `/api/health`
 
 ## References

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ AniListCal uses a **Backend-for-Frontend (BFF)** pattern:
 | Backend | Express 4, TypeScript |
 | Auth | Passport.js + express-session + OAuth2 |
 | Session store | Redis (production) or in-memory (local dev) |
-| Token storage | `node-persist` on disk (`.persist-storage/`) |
+| Token storage | Redis when `REDIS_URL` is set; else `node-persist` on disk (`.persist-storage/`, local dev) |
 | External API | AniList GraphQL + OAuth 2.0 |
 | Hosting | Railway (production) |
 
@@ -86,7 +86,7 @@ AniListCal/
 │   ├── index.ts               # Server entry point
 │   ├── auth/                  # Passport, sessions, OAuth, requireAuth
 │   ├── routes/                # Route registration, middleware, handlers
-│   ├── storage.ts             # node-persist token/user storage
+│   ├── storage.ts             # AniList token/user storage (Redis or node-persist)
 │   └── vite.ts                # Vite dev middleware + prod static serving
 ├── docs/
 │   ├── ARCHITECTURE.md        # This file
@@ -157,7 +157,7 @@ Full decision record: [docs/adr/001-passport-session-auth.md](./adr/001-passport
 | Concern | Approach |
 |---------|----------|
 | Browser ↔ API identity | HttpOnly cookie `sid`, `credentials: "include"` on all auth fetches |
-| AniList access tokens | Stored server-side only in `node-persist`; never sent to the browser |
+| AniList access tokens | Stored server-side in Redis (prod) or `node-persist` (local); never sent to the browser |
 | OAuth flow | Server-side redirect via Passport strategy named **`anilist`** |
 | Session persistence (prod) | Redis via `connect-redis` when `REDIS_URL` is set |
 | Session persistence (dev) | In-memory `memorystore` when `REDIS_URL` is unset |
@@ -179,7 +179,7 @@ sequenceDiagram
   Browser->>AniListCal: GET /api/auth/callback
   AniListCal->>AniList: Exchange code for access token (JSON body)
   AniListCal->>AniList: Fetch Viewer profile (GraphQL)
-  AniListCal->>AniListCal: Persist token + user in node-persist
+  AniListCal->>AniListCal: Persist token + user in Redis (or node-persist locally)
   AniListCal->>Redis: Save session (user id)
   AniListCal->>Browser: Set-Cookie sid; redirect to /
   Browser->>AniListCal: POST /api/anilist/proxy (cookie)
@@ -198,7 +198,7 @@ sequenceDiagram
 | `server/auth/sessionConfig.ts` | Cookie name, max age, secure flags |
 | `server/auth/requireAuth.ts` | Middleware: session check + load AniList token onto `req` |
 | `server/auth/clearSession.ts` | Token expiry detection and session teardown |
-| `server/storage.ts` | `node-persist` read/write for tokens and user info |
+| `server/storage.ts` | Redis or `node-persist` read/write for tokens and user info |
 
 ### Key client files
 
@@ -291,7 +291,7 @@ The server proxy (`server/routes/handlers/proxyHandler.ts`) forwards `{ query, v
 |-------|----------|----------|
 | React Query | `client/src/lib/queryClient.ts` | Default stale 5 min, gc 30 min; pages override via `commonQueryOptions` |
 | localStorage | `client/src/lib/cache-service.ts` | Anime list: 30 min TTL; details: 24 hr TTL; LRU eviction (10 list / 30 detail entries) |
-| Server | — | No GraphQL response cache; tokens cached in `node-persist` with ~1 year TTL |
+| Server | Redis (prod) / node-persist (local) | AniList tokens + user profile; encrypted at rest |
 | Session | Redis / memory | Session cookie references user id; token loaded on each authenticated request |
 
 Mutations call `clearAnimeListCache()` after success to invalidate the localStorage list cache. React Query keys are invalidated by mutation hooks where needed.
@@ -487,14 +487,14 @@ HTTP request
 
 ### Token storage
 
-`server/storage.ts` uses `node-persist` with files under `.persist-storage/`:
+`server/storage.ts` stores AniList credentials server-side, encrypted with AES-256-GCM via `SESSION_SECRET`:
 
-| Key pattern | Content |
-|-------------|---------|
-| `anilist_token_{userId}` | Access token + expiry metadata |
-| `user_info_{userId}` | Username, avatar URL |
+| Backend | When | Key pattern |
+|---------|------|-------------|
+| **Redis** | `REDIS_URL` set (production) | `anilistcal:store:token:{userId}`, `anilistcal:store:user:{userId}` |
+| **node-persist** | Local dev without Redis | `anilist_token_{userId}`, `user_info_{userId}` under `.persist-storage/` |
 
-Expired tokens are cleaned up on an hourly interval. On ephemeral containers (Railway), this directory is **lost on redeploy** unless a persistent volume is mounted. Redis sessions survive redeploys; AniList tokens may not.
+Tokens use Redis `EX` TTL (or node-persist TTL) aligned with AniList's `expires_in`. With `REDIS_URL` configured, both sessions and AniList tokens survive deploys on Railway.
 
 ### Vite integration
 
@@ -648,7 +648,7 @@ Umami script loaded in `client/index.html`. Allowed in production CSP (`connect-
 | **Stale profile page** | Dead Connect/Disconnect buttons; form calls non-existent `PATCH /api/users/:id` |
 | **Legacy query keys** | `["/api/users/current"]` references a removed REST users API; identity is OAuth-only |
 | **Duplicate QueryClientProvider** | `main.tsx` wraps `App` in a provider that duplicates the one inside `App.tsx` |
-| **Token persistence on deploy** | `.persist-storage/` is ephemeral on Railway unless a volume is mounted; users may need to re-login after redeploy even with Redis sessions |
+| **Token persistence without Redis** | Production should set `REDIS_URL` so AniList tokens survive deploys (same Redis instance as sessions). Without it, tokens fall back to ephemeral disk |
 | **Tag filter tests/polish** | Filter store and collapsible UI need tests and a styling pass |
 | **No server-side Sentry** | Client errors are tracked; server/proxy errors are log-only |
 | **Timezone display** | Airing times use local `Date`; AniList exposes user timezone but it is not surfaced in the UI |

--- a/docs/adr/001-passport-session-auth.md
+++ b/docs/adr/001-passport-session-auth.md
@@ -31,7 +31,7 @@ Adopt **Passport.js + express-session** with **HttpOnly session cookies**:
 | Session store (production) | Redis via `connect-redis` (`REDIS_URL`) |
 | Session store (local dev) | In-memory (`memorystore`) when `REDIS_URL` is unset |
 | OAuth | `passport-oauth2` strategy named **`anilist`** (server-side redirect flow) |
-| AniList tokens | Stored server-side only (`node-persist`), never exposed to the browser |
+| AniList tokens | Stored server-side only (Redis in production, `node-persist` locally), never exposed to the browser |
 | AniList token expiry | Revoke stored token, destroy session, return `401` with `ANILIST_TOKEN_EXPIRED` |
 
 ### Auth flow (current)
@@ -50,7 +50,7 @@ sequenceDiagram
   Browser->>AniListCal: GET /api/auth/callback
   AniListCal->>AniList: Exchange code for access token (JSON body)
   AniListCal->>AniList: Fetch Viewer profile (GraphQL)
-  AniListCal->>AniListCal: Persist token + user in node-persist
+  AniListCal->>AniListCal: Persist token + user in Redis (or node-persist locally)
   AniListCal->>Redis: Save session (user id)
   AniListCal->>Browser: Set-Cookie sid; redirect to /
   Browser->>AniListCal: POST /api/anilist/proxy (cookie)
@@ -89,9 +89,9 @@ sequenceDiagram
 | Data | Store | Survives deploy? |
 |------|-------|------------------|
 | Session id → user id | Redis (prod) | Yes, when `REDIS_URL` is set |
-| AniList access token + profile | `node-persist` (`.persist-storage/`) | **No** on ephemeral containers unless a volume is mounted |
+| AniList access token + profile | Redis when `REDIS_URL` is set; else `node-persist` (`.persist-storage/`) | Yes with Redis |
 
-Users may need to re-authorize with AniList after a deploy even when Redis sessions survive, if the container disk is wiped. A future improvement could move AniList tokens into Redis or a mounted volume.
+Users may need to re-authorize with AniList after a deploy only when `REDIS_URL` is unset (tokens fall back to ephemeral disk). With Redis configured, sessions and AniList tokens both survive deploys.
 
 ## Environment variables
 
@@ -113,7 +113,7 @@ BACKEND_CALLBACK_URL=https://anilistcal.com/api/auth/callback
 
 **No longer required:** `VITE_ANILIST_CLIENT_ID` (old client-side OAuth redirect).
 
-**Not used:** `DATABASE_URL` — Postgres is not part of auth; tokens use `node-persist`.
+**Not used:** `DATABASE_URL` — Postgres is not part of auth; tokens use Redis (production) or `node-persist` (local dev).
 
 ## Production deployment (Railway)
 
@@ -134,7 +134,7 @@ BACKEND_CALLBACK_URL=https://anilistcal.com/api/auth/callback
 ### Negative / trade-offs
 
 - Production **requires Redis** for durable login sessions.
-- AniList tokens on container disk remain ephemeral without extra storage.
+- AniList tokens on container disk remain ephemeral without Redis; set `REDIS_URL` in production so tokens persist alongside sessions.
 - OAuth login must run in a real browser (not Cursor embedded preview).
 - Slightly more moving parts (Passport, Redis, session middleware) than the old custom tokens.
 

--- a/server/__tests__/anilistOAuth.test.ts
+++ b/server/__tests__/anilistOAuth.test.ts
@@ -67,7 +67,7 @@ describe("anilistOAuth", () => {
     expect(fetchMock).toHaveBeenNthCalledWith(1, ANILIST_TOKEN_URL, expect.objectContaining({ method: "POST" }));
     expect(fetchMock).toHaveBeenNthCalledWith(2, ANILIST_GRAPHQL_URL, expect.objectContaining({ method: "POST" }));
     expect(storeTokenSpy).toHaveBeenCalledWith("123", "anilist_token", 3600);
-    expect(storeUserInfoSpy).toHaveBeenCalledWith("123", "TestUser", "avatar_url");
+    expect(storeUserInfoSpy).toHaveBeenCalledWith("123", "TestUser", "avatar_url", 3600);
     expect(user).toEqual({
       id: "123",
       username: "TestUser",

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { PersistentStorage } from '../storage';
 import { decryptToken } from '../tokenCrypto';
 
-const mockInit = vi.fn().mockResolvedValue(undefined);
-const mockSetItem = vi.fn();
-const mockGetItem = vi.fn();
-const mockRemoveItem = vi.fn();
-const mockClear = vi.fn();
+const {
+  mockInit,
+  mockSetItem,
+  mockGetItem,
+  mockRemoveItem,
+} = vi.hoisted(() => ({
+  mockInit: vi.fn().mockResolvedValue(undefined),
+  mockSetItem: vi.fn(),
+  mockGetItem: vi.fn(),
+  mockRemoveItem: vi.fn(),
+}));
 
 vi.mock('node-persist', () => ({
   default: {
@@ -14,7 +19,7 @@ vi.mock('node-persist', () => ({
     setItem: mockSetItem,
     getItem: mockGetItem,
     removeItem: mockRemoveItem,
-    clear: mockClear,
+    clear: vi.fn(),
     valuesWithKeyMatch: vi.fn().mockResolvedValue([]),
   },
 }));
@@ -27,14 +32,14 @@ const testUserInfo = {
 
 const testToken = 'test-access-token';
 
-describe('PersistentStorage', () => {
-  let storage: PersistentStorage;
+describe('PersistentStorage (node-persist)', () => {
+  let PersistentStorage: typeof import('../storage').PersistentStorage;
+  let storage: import('../storage').PersistentStorage;
 
   beforeEach(async () => {
-    vi.resetModules();
     vi.clearAllMocks();
-    const storageModule = await import('../storage');
-    storage = new storageModule.PersistentStorage();
+    ({ PersistentStorage } = await import('../storage'));
+    storage = new PersistentStorage();
     await new Promise(setImmediate);
   });
 
@@ -57,7 +62,6 @@ describe('PersistentStorage', () => {
         { ttl }
       );
 
-      // Stored token is encrypted at rest but round-trips back to the original.
       const storedToken = mockSetItem.mock.calls[0][1].accessToken;
       expect(storedToken).not.toBe(testToken);
       expect(decryptToken(storedToken)).toBe(testToken);
@@ -100,5 +104,79 @@ describe('PersistentStorage', () => {
       const retrievedInfo = await storage.getUserInfo(userIdStr);
       expect(retrievedInfo).toEqual(userInfoToStore);
     });
+  });
+});
+
+describe('PersistentStorage (Redis)', () => {
+  const mockRedisGet = vi.fn();
+  const mockRedisSet = vi.fn();
+  const mockRedisDel = vi.fn();
+
+  const redisClient = {
+    get: mockRedisGet,
+    set: mockRedisSet,
+    del: mockRedisDel,
+  };
+
+  let initStorage: typeof import('../storage').initStorage;
+  let storage: import('../storage').PersistentStorage;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ initStorage } = await import('../storage'));
+    storage = initStorage(redisClient);
+  });
+
+  it('stores encrypted tokens in Redis with EX TTL', async () => {
+    const userIdStr = testUserInfo.userId.toString();
+    const expiresInSec = 3600;
+
+    await storage.storeToken(userIdStr, testToken, expiresInSec);
+
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      `anilistcal:store:token:${userIdStr}`,
+      expect.stringContaining('"accessToken":"enc:v1:'),
+      { EX: expiresInSec }
+    );
+    expect(mockInit).not.toHaveBeenCalled();
+  });
+
+  it('retrieves and decrypts a token from Redis', async () => {
+    const userIdStr = testUserInfo.userId.toString();
+    mockRedisGet.mockResolvedValue(
+      JSON.stringify({
+        userId: userIdStr,
+        accessToken: testToken,
+        expiresAt: Date.now() + 3600000,
+      })
+    );
+
+    const token = await storage.getToken(userIdStr);
+    expect(mockRedisGet).toHaveBeenCalledWith(`anilistcal:store:token:${userIdStr}`);
+    expect(token).toBe(testToken);
+  });
+
+  it('revokes tokens via Redis DEL', async () => {
+    const userIdStr = testUserInfo.userId.toString();
+    mockRedisGet.mockResolvedValue('{"userId":"123"}');
+
+    const revoked = await storage.revokeToken(userIdStr);
+    expect(revoked).toBe(true);
+    expect(mockRedisDel).toHaveBeenCalledWith(`anilistcal:store:token:${userIdStr}`);
+  });
+
+  it('stores and retrieves user info in Redis', async () => {
+    const userIdStr = testUserInfo.userId.toString();
+    const userInfo = { username: testUserInfo.userName, avatarUrl: testUserInfo.avatar };
+
+    await storage.storeUserInfo(userIdStr, testUserInfo.userName, testUserInfo.avatar);
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      `anilistcal:store:user:${userIdStr}`,
+      JSON.stringify(userInfo)
+    );
+
+    mockRedisGet.mockResolvedValue(JSON.stringify(userInfo));
+    const retrieved = await storage.getUserInfo(userIdStr);
+    expect(retrieved).toEqual(userInfo);
   });
 });

--- a/server/__tests__/storage.test.ts
+++ b/server/__tests__/storage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { decryptToken } from '../tokenCrypto';
+import { decryptToken, encryptToken } from '../tokenCrypto';
 
 const {
   mockInit,
@@ -146,7 +146,7 @@ describe('PersistentStorage (Redis)', () => {
     mockRedisGet.mockResolvedValue(
       JSON.stringify({
         userId: userIdStr,
-        accessToken: testToken,
+        accessToken: encryptToken(testToken),
         expiresAt: Date.now() + 3600000,
       })
     );
@@ -168,11 +168,18 @@ describe('PersistentStorage (Redis)', () => {
   it('stores and retrieves user info in Redis', async () => {
     const userIdStr = testUserInfo.userId.toString();
     const userInfo = { username: testUserInfo.userName, avatarUrl: testUserInfo.avatar };
+    const expiresInSec = 3600;
 
-    await storage.storeUserInfo(userIdStr, testUserInfo.userName, testUserInfo.avatar);
+    await storage.storeUserInfo(
+      userIdStr,
+      testUserInfo.userName,
+      testUserInfo.avatar,
+      expiresInSec
+    );
     expect(mockRedisSet).toHaveBeenCalledWith(
       `anilistcal:store:user:${userIdStr}`,
-      JSON.stringify(userInfo)
+      JSON.stringify(userInfo),
+      { EX: expiresInSec }
     );
 
     mockRedisGet.mockResolvedValue(JSON.stringify(userInfo));

--- a/server/auth/anilistOAuth.ts
+++ b/server/auth/anilistOAuth.ts
@@ -110,7 +110,12 @@ export async function persistAniListLogin(
     accessToken,
     typeof expiresIn === "number" ? expiresIn : undefined
   );
-  await storage.storeUserInfo(userId, viewer.name, viewer.avatar?.medium);
+  await storage.storeUserInfo(
+    userId,
+    viewer.name,
+    viewer.avatar?.medium,
+    typeof expiresIn === "number" ? expiresIn : undefined
+  );
 
   prefetchListSnapshots(userId, accessToken);
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,6 +4,7 @@ import { registerConfigRoutes } from "./config";
 import { registerAuthRoutes } from "./auth";
 import { createSessionStore, type SessionStoreSetup } from "../auth/session";
 import { initCacheStore } from "../cache/cacheStore";
+import { initStorage } from "../storage";
 
 declare global {
   namespace Express {
@@ -22,7 +23,9 @@ declare global {
 
 export async function registerAllRoutes(app: Express): Promise<SessionStoreSetup> {
   const sessionSetup = await createSessionStore();
-  initCacheStore(sessionSetup.redisClient as Parameters<typeof initCacheStore>[0]);
+  const redisClient = sessionSetup.redisClient as Parameters<typeof initCacheStore>[0];
+  initCacheStore(redisClient);
+  initStorage(redisClient);
   registerMiddleware(app, sessionSetup.store);
   registerConfigRoutes(app);
   registerAuthRoutes(app);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -141,14 +141,21 @@ export class PersistentStorage {
     }
   }
 
-  async storeUserInfo(userId: string, username: string, avatarUrl?: string): Promise<void> {
+  async storeUserInfo(
+    userId: string,
+    username: string,
+    avatarUrl?: string,
+    expiresInSeconds?: number
+  ): Promise<void> {
     await this.ensureInitialized();
     const userInfo = { username, avatarUrl };
 
     if (this.useRedis && this.redisClient) {
+      const ttlSec = this.resolveTokenTtlSeconds(expiresInSeconds);
       await this.redisClient.set(
         RedisKeys.USER_INFO(userId),
-        JSON.stringify(userInfo)
+        JSON.stringify(userInfo),
+        { EX: ttlSec }
       );
       return;
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -42,11 +42,6 @@ export class PersistentStorage {
       this.isInitialized = true;
       logger.debug('[Storage] Using Redis for AniList tokens and user info.');
     } else {
-      if (process.env.NODE_ENV === 'production') {
-        console.warn(
-          '[Storage] REDIS_URL is not set — AniList tokens use ephemeral disk storage and will be lost on deploy. Set REDIS_URL to persist tokens alongside sessions.'
-        );
-      }
       void this.initializeNodePersist();
     }
   }
@@ -227,5 +222,10 @@ export let storage: PersistentStorage = new PersistentStorage();
  */
 export function initStorage(redisClient?: RedisClientForStorage): PersistentStorage {
   storage = new PersistentStorage(redisClient);
+  if (!redisClient && process.env.NODE_ENV === 'production') {
+    console.warn(
+      '[Storage] REDIS_URL is not set — AniList tokens use ephemeral disk storage and will be lost on deploy. Set REDIS_URL to persist tokens alongside sessions.'
+    );
+  }
   return storage;
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3,6 +3,7 @@ import { AniListToken, AniListUser } from './types';
 import { decryptToken, encryptToken } from './tokenCrypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { logger } from './logger';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -10,19 +11,47 @@ const __dirname = path.dirname(__filename);
 const DEFAULT_ANILIST_EXPIRES_IN_SEC = 365 * 24 * 60 * 60;
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 
+/** Separate from session (`anilistcal:sess:`) and API cache keys. */
+export const STORAGE_REDIS_KEY_PREFIX = 'anilistcal:store:';
+
 const Keys = {
   ANILIST_TOKEN: (userId: string) => `anilist_token_${userId}`,
   USER_INFO: (userId: string) => `user_info_${userId}`,
 };
 
+const RedisKeys = {
+  ANILIST_TOKEN: (userId: string) => `${STORAGE_REDIS_KEY_PREFIX}token:${userId}`,
+  USER_INFO: (userId: string) => `${STORAGE_REDIS_KEY_PREFIX}user:${userId}`,
+};
+
+interface RedisClientForStorage {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, options?: { EX?: number }): Promise<unknown>;
+  del(key: string | string[]): Promise<unknown>;
+}
+
 export class PersistentStorage {
   private isInitialized = false;
+  private redisClient?: RedisClientForStorage;
+  private useRedis = false;
 
-  constructor() {
-    this.initializeStorage();
+  constructor(redisClient?: RedisClientForStorage) {
+    if (redisClient) {
+      this.redisClient = redisClient;
+      this.useRedis = true;
+      this.isInitialized = true;
+      logger.debug('[Storage] Using Redis for AniList tokens and user info.');
+    } else {
+      if (process.env.NODE_ENV === 'production') {
+        console.warn(
+          '[Storage] REDIS_URL is not set — AniList tokens use ephemeral disk storage and will be lost on deploy. Set REDIS_URL to persist tokens alongside sessions.'
+        );
+      }
+      void this.initializeNodePersist();
+    }
   }
 
-  private async initializeStorage() {
+  private async initializeNodePersist() {
     try {
       await nodePersist.init({
         dir: path.join(__dirname, '../.persist-storage'),
@@ -30,7 +59,7 @@ export class PersistentStorage {
         logging: process.env.NODE_ENV !== 'production',
       });
       this.isInitialized = true;
-      console.log('[Storage] node-persist initialized.');
+      logger.debug('[Storage] Using node-persist for AniList tokens (local dev).');
       setInterval(() => this.cleanupExpiredTokens(), CLEANUP_INTERVAL_MS);
     } catch (error) {
       console.error('[Storage] Failed to initialize node-persist:', error);
@@ -47,62 +76,122 @@ export class PersistentStorage {
     }
   }
 
+  private resolveTokenTtlSeconds(expiresInSeconds?: number): number {
+    if (
+      typeof expiresInSeconds === 'number' &&
+      Number.isFinite(expiresInSeconds) &&
+      expiresInSeconds > 0
+    ) {
+      return Math.min(expiresInSeconds, 2 * 365 * 24 * 60 * 60);
+    }
+    return DEFAULT_ANILIST_EXPIRES_IN_SEC;
+  }
+
   async storeToken(
     userId: string,
     accessToken: string,
     expiresInSeconds?: number
   ): Promise<void> {
     await this.ensureInitialized();
-    const key = Keys.ANILIST_TOKEN(userId);
-    const sec =
-      typeof expiresInSeconds === 'number' && Number.isFinite(expiresInSeconds) && expiresInSeconds > 0
-        ? Math.min(expiresInSeconds, 2 * 365 * 24 * 60 * 60)
-        : DEFAULT_ANILIST_EXPIRES_IN_SEC;
-    const ttlMs = sec * 1000;
+    const ttlSec = this.resolveTokenTtlSeconds(expiresInSeconds);
+    const ttlMs = ttlSec * 1000;
     const tokenData: AniListToken = {
       userId,
       accessToken: encryptToken(accessToken),
-      expiresAt: Date.now() + ttlMs
+      expiresAt: Date.now() + ttlMs,
     };
-    await nodePersist.setItem(key, tokenData, { ttl: ttlMs });
+
+    if (this.useRedis && this.redisClient) {
+      await this.redisClient.set(
+        RedisKeys.ANILIST_TOKEN(userId),
+        JSON.stringify(tokenData),
+        { EX: ttlSec }
+      );
+      return;
+    }
+
+    await nodePersist.setItem(Keys.ANILIST_TOKEN(userId), tokenData, { ttl: ttlMs });
   }
 
   async getToken(userId: string): Promise<string | null> {
     await this.ensureInitialized();
-    const key = Keys.ANILIST_TOKEN(userId);
-    const tokenData: AniListToken | undefined = await nodePersist.getItem(key);
+
+    let tokenData: AniListToken | undefined;
+
+    if (this.useRedis && this.redisClient) {
+      const raw = await this.redisClient.get(RedisKeys.ANILIST_TOKEN(userId));
+      if (!raw) return null;
+      try {
+        tokenData = JSON.parse(raw) as AniListToken;
+      } catch (error) {
+        logger.warn(`[Storage] Invalid token JSON for user ${userId}, removing.`, error);
+        await this.redisClient.del(RedisKeys.ANILIST_TOKEN(userId));
+        return null;
+      }
+    } else {
+      tokenData = await nodePersist.getItem(Keys.ANILIST_TOKEN(userId));
+    }
 
     if (!tokenData || (tokenData.expiresAt && tokenData.expiresAt < Date.now())) {
-      if (tokenData) await nodePersist.removeItem(key);
+      if (tokenData) await this.revokeToken(userId);
       return null;
     }
 
     try {
       return decryptToken(tokenData.accessToken);
     } catch (error) {
-      // Token can't be decrypted (e.g. SESSION_SECRET rotated). Drop it and
-      // force re-authentication rather than returning a broken token.
       console.warn(`[Storage] Failed to decrypt token for user ${userId}, removing it.`, error);
-      await nodePersist.removeItem(key);
+      await this.revokeToken(userId);
       return null;
     }
   }
 
   async storeUserInfo(userId: string, username: string, avatarUrl?: string): Promise<void> {
     await this.ensureInitialized();
-    const key = Keys.USER_INFO(userId);
     const userInfo = { username, avatarUrl };
-    await nodePersist.setItem(key, userInfo);
+
+    if (this.useRedis && this.redisClient) {
+      await this.redisClient.set(
+        RedisKeys.USER_INFO(userId),
+        JSON.stringify(userInfo)
+      );
+      return;
+    }
+
+    await nodePersist.setItem(Keys.USER_INFO(userId), userInfo);
   }
 
   async getUserInfo(userId: string): Promise<Omit<AniListUser, 'id'> | null> {
     await this.ensureInitialized();
-    const key = Keys.USER_INFO(userId);
-    return (await nodePersist.getItem(key)) || null;
+
+    if (this.useRedis && this.redisClient) {
+      const raw = await this.redisClient.get(RedisKeys.USER_INFO(userId));
+      if (!raw) return null;
+      try {
+        return JSON.parse(raw) as Omit<AniListUser, 'id'>;
+      } catch (error) {
+        logger.warn(`[Storage] Invalid user info JSON for user ${userId}, removing.`, error);
+        await this.redisClient.del(RedisKeys.USER_INFO(userId));
+        return null;
+      }
+    }
+
+    return (await nodePersist.getItem(Keys.USER_INFO(userId))) || null;
   }
 
   async revokeToken(userId: string): Promise<boolean> {
     await this.ensureInitialized();
+
+    if (this.useRedis && this.redisClient) {
+      const key = RedisKeys.ANILIST_TOKEN(userId);
+      const existing = await this.redisClient.get(key);
+      if (existing) {
+        await this.redisClient.del(key);
+        return true;
+      }
+      return false;
+    }
+
     const anilistKey = Keys.ANILIST_TOKEN(userId);
     const exists = await nodePersist.getItem(anilistKey);
     if (exists) {
@@ -113,7 +202,8 @@ export class PersistentStorage {
   }
 
   async cleanupExpiredTokens(): Promise<void> {
-    if (!this.isInitialized) return;
+    if (!this.isInitialized || this.useRedis) return;
+
     console.log('[Storage] Running explicit cleanup...');
     const now = Date.now();
 
@@ -128,4 +218,14 @@ export class PersistentStorage {
   }
 }
 
-export const storage = new PersistentStorage();
+/** Default instance (node-persist); replaced by initStorage() when Redis is available. */
+export let storage: PersistentStorage = new PersistentStorage();
+
+/**
+ * Wire AniList token storage to Redis when REDIS_URL is available (production).
+ * Falls back to node-persist on disk for local dev without Redis.
+ */
+export function initStorage(redisClient?: RedisClientForStorage): PersistentStorage {
+  storage = new PersistentStorage(redisClient);
+  return storage;
+}

--- a/server/tokenCrypto.ts
+++ b/server/tokenCrypto.ts
@@ -1,7 +1,7 @@
 import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "crypto";
 
 /**
- * Encrypts AniList access tokens before they are written to disk (node-persist).
+ * Encrypts AniList access tokens before they are written at rest (Redis or node-persist).
  * Tokens grant full API access to a user's AniList account, so they must not
  * sit in plaintext on the filesystem.
  *


### PR DESCRIPTION
## Summary
- Persist AniList OAuth tokens and user profile in Redis when `REDIS_URL` is set, using the same client as sessions
- Keep node-persist on disk as the fallback for local dev without Redis
- Tokens remain encrypted at rest (AES-256-GCM via `SESSION_SECRET`)

## Problem
Sessions survived deploys via Redis, but AniList tokens lived in ephemeral `.persist-storage/` on Railway. After a redeploy, users could appear logged in while API calls failed until re-auth.

## Test plan
- [x] `yarn test` (72 tests pass, including new Redis storage tests)
- [ ] Log in on production, redeploy, confirm list/calendar still loads without re-auth
- [ ] Confirm startup log shows Redis storage backend in production


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where long-lived AniList credentials are stored and how production depends on REDIS_URL; mitigated by encryption, TTLs, tests, and the same Redis client already used for sessions.
> 
> **Overview**
> **AniList OAuth tokens and cached profile now persist in Redis** when `REDIS_URL` is available, using the same Redis client as sessions and API cache. Local dev without Redis still uses **node-persist** on disk.
> 
> `server/storage.ts` gains a dual backend: Redis keys under `anilistcal:store:token:` / `anilistcal:store:user:` with **AES-256-GCM** ciphertext unchanged and **Redis `EX` TTL** aligned to AniList `expires_in`. `initStorage()` is called from route registration so the shared `storage` singleton matches production Redis; production without Redis logs a warning. OAuth login passes **`expires_in` into `storeUserInfo`** so profile rows expire with tokens on Redis.
> 
> Docs and checklists now state that **sessions and AniList API access both survive redeploys** with `REDIS_URL`, drop the old “mount `.persist-storage`” optional step, and add **Render decommission** notes. Tests cover the Redis read/write/revoke path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ca708229d89af78adadc7525394f7f7be4377a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->