### PR TITLE
Fix episode increment when season total is unknown

### DIFF
--- a/client/src/components/__tests__/episode-controls.test.tsx
+++ b/client/src/components/__tests__/episode-controls.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { EpisodeControls } from "../episode-controls";
+import "@testing-library/jest-dom";
+
+const updateProgress = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useUpdateProgress: () => ({
+    updateProgress,
+    isUpdating: false,
+  }),
+}));
+
+describe("EpisodeControls", () => {
+  beforeEach(() => {
+    updateProgress.mockClear();
+  });
+
+  it("allows incrementing when season total is unknown (0)", () => {
+    render(
+      <EpisodeControls mediaId={1} currentEpisode={3} totalEpisodes={0} />
+    );
+
+    const increase = screen.getByRole("button", { name: "Increase episode" });
+    expect(increase).toBeEnabled();
+
+    fireEvent.click(increase);
+
+    expect(updateProgress).toHaveBeenCalledWith({ mediaId: 1, progress: 4 });
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("blocks incrementing once known total is reached", () => {
+    render(
+      <EpisodeControls mediaId={1} currentEpisode={12} totalEpisodes={12} />
+    );
+
+    const increase = screen.getByRole("button", { name: "Increase episode" });
+    expect(increase).toBeDisabled();
+
+    fireEvent.click(increase);
+    expect(updateProgress).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/episode-controls.tsx
+++ b/client/src/components/episode-controls.tsx
@@ -44,9 +44,13 @@ export function EpisodeControls({
     }
   };
 
+  // AniList often returns null episodes for ongoing seasons; callers coerce that
+  // to 0. Only apply an upper bound when a real season total is known.
+  const hasKnownTotal = totalEpisodes > 0;
+  const canIncrement = !hasKnownTotal || localProgress < totalEpisodes;
+
   const handleIncrement = (e: React.MouseEvent) => {
     e.stopPropagation();
-    const canIncrement = localProgress < totalEpisodes;
 
     if (canIncrement && !isUpdating) {
       const newProgress = localProgress + 1;
@@ -62,11 +66,11 @@ export function EpisodeControls({
       "inline-flex items-center flex-shrink-0 gap-1 bg-background/80 backdrop-blur-sm p-1 rounded-lg border border-border/50",
   }[variant];
 
-  const incrementDisabled = isUpdating || localProgress >= totalEpisodes;
+  const incrementDisabled = isUpdating || !canIncrement;
   const decrementDisabled = isUpdating || localProgress === 0;
   const progressColorClass = getProgressColor(
     currentEpisode,
-    targetEpisode ?? totalEpisodes
+    targetEpisode || (hasKnownTotal ? totalEpisodes : null)
   );
 
   return (


### PR DESCRIPTION
## Summary
- Allow increasing watch progress when AniList has no known season episode total (`episodes` null → callers pass `0`)
- Add unit coverage for unknown-total increment and known-total cap

## Test plan
- [x] `yarn vitest run client/src/components/__tests__/episode-controls.test.tsx`
- [ ] On a CURRENT show with unknown episode total, confirm + increments progress
- [ ] On a show with a known total at the final episode, confirm + stays disabled


Made with [Cursor](https://cursor.com)