### PR TITLE
Add search page to change watch status

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { ThemeProvider } from "@/components/theme-provider";
 import CalendarPage from "./pages/calendar";
+import SearchPage from "./pages/search";
 import { QueryProvider } from "@/components/query-provider";
 import { queryKeys } from "@/lib/queryKeys";
 
@@ -79,6 +80,7 @@ function Router() {
         </div>
       )} />
       <Route path="/" component={() => <ProtectedRoute component={Home} />} />
+      <Route path="/search" component={() => <ProtectedRoute component={SearchPage} />} />
       <Route path="/calendar" component={() => <ProtectedRoute component={CalendarPage} />} />
       <Route path="/profile" component={() => <ProtectedRoute component={Profile} />} />
       <Route path="/show/:id" component={() => <ProtectedRoute component={Show} />} />

--- a/client/src/components/layout.tsx
+++ b/client/src/components/layout.tsx
@@ -1,12 +1,13 @@
 import { Link, useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
-import { Home, Calendar, User, LogOut } from "lucide-react";
+import { Home, Calendar, Search, User, LogOut } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { logout } from "@/lib/auth";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
   { href: "/", label: "Home", icon: Home },
+  { href: "/search", label: "Search", icon: Search },
   { href: "/calendar", label: "Calendar", icon: Calendar },
   { href: "/profile", label: "Profile", icon: User },
 ] as const;
@@ -59,7 +60,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur supports-[backdrop-filter]:bg-background/60 md:hidden"
         aria-label="Primary"
       >
-        <div className="grid h-16 grid-cols-3">
+        <div className="grid h-16 grid-cols-4">
           {NAV_ITEMS.map(({ href, label, icon: Icon }) => {
             const active = isNavActive(location, href);
             return (

--- a/client/src/components/search/SearchResultRow.tsx
+++ b/client/src/components/search/SearchResultRow.tsx
@@ -1,0 +1,94 @@
+import { Link } from "wouter";
+import { StatusSelector } from "@/components/status-selector";
+import type { SearchMediaResult } from "@/lib/anilist";
+import { MediaFormat, MediaListStatus } from "@/generated/graphql";
+
+interface SearchResultRowProps {
+  media: NonNullable<SearchMediaResult>;
+}
+
+function formatMediaFormat(format: MediaFormat | null | undefined): string | null {
+  if (!format) return null;
+
+  switch (format) {
+    case MediaFormat.Tv:
+      return "TV";
+    case MediaFormat.TvShort:
+      return "TV Short";
+    case MediaFormat.Movie:
+      return "Movie";
+    case MediaFormat.Special:
+      return "Special";
+    case MediaFormat.Ova:
+      return "OVA";
+    case MediaFormat.Ona:
+      return "ONA";
+    case MediaFormat.Music:
+      return "Music";
+    case MediaFormat.Manga:
+      return "Manga";
+    case MediaFormat.Novel:
+      return "Novel";
+    case MediaFormat.OneShot:
+      return "One Shot";
+    default: {
+      const _exhaustive: never = format;
+      return _exhaustive;
+    }
+  }
+}
+
+export function SearchResultRow({ media }: SearchResultRowProps) {
+  const title =
+    media.title?.english || media.title?.romaji || media.title?.native || "Unknown";
+  const imageUrl = media.coverImage?.large ?? "";
+  const formatLabel = formatMediaFormat(media.format);
+  const metaParts = [
+    formatLabel,
+    media.seasonYear ? String(media.seasonYear) : null,
+    media.episodes != null ? `${media.episodes} eps` : null,
+  ].filter(Boolean);
+
+  const currentStatus: MediaListStatus | null =
+    media.mediaListEntry?.status ?? null;
+
+  return (
+    <div className="flex items-center gap-3 sm:gap-4 py-3 border-b border-border/60 last:border-b-0">
+      <Link href={`/show/${media.id}`} className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4">
+        <div className="h-16 w-11 sm:h-20 sm:w-14 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : null}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="font-medium text-sm sm:text-base line-clamp-2 hover:text-primary">
+            {title}
+          </h3>
+          {metaParts.length > 0 && (
+            <p className="mt-1 text-xs sm:text-sm text-muted-foreground">
+              {metaParts.join(" · ")}
+            </p>
+          )}
+        </div>
+      </Link>
+
+      <div
+        className="w-[9.5rem] sm:w-44 flex-shrink-0"
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        <StatusSelector
+          mediaId={media.id}
+          currentStatus={currentStatus}
+          variant="compact"
+          className="w-full"
+        />
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/search/__tests__/SearchResultRow.test.tsx
+++ b/client/src/components/search/__tests__/SearchResultRow.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MediaFormat, MediaListStatus } from "@/generated/graphql";
+import { SearchResultRow } from "../SearchResultRow";
+
+const updateStatus = vi.fn();
+
+vi.mock("@/hooks/useUpdateStatus", () => ({
+  useUpdateStatus: () => ({
+    updateStatus,
+    isUpdating: false,
+  }),
+}));
+
+describe("SearchResultRow", () => {
+  beforeEach(() => {
+    updateStatus.mockClear();
+  });
+
+  it("renders title metadata and updates watch status", () => {
+    render(
+      <SearchResultRow
+        media={{
+          id: 42,
+          title: {
+            romaji: "Frieren",
+            english: "Frieren: Beyond Journey's End",
+            native: null,
+          },
+          coverImage: { large: "https://example.com/frieren.jpg", extraLarge: null },
+          status: null,
+          format: MediaFormat.Tv,
+          episodes: 28,
+          seasonYear: 2023,
+          mediaListEntry: {
+            id: 1,
+            status: MediaListStatus.Planning,
+            progress: 0,
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText("Frieren: Beyond Journey's End")
+    ).toBeInTheDocument();
+    expect(screen.getByText("TV · 2023 · 28 eps")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/show/42");
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "Watching" }));
+
+    expect(updateStatus).toHaveBeenCalledWith({
+      mediaId: 42,
+      status: MediaListStatus.Current,
+    });
+  });
+
+  it("allows setting status when the show is not on the list", () => {
+    render(
+      <SearchResultRow
+        media={{
+          id: 7,
+          title: { romaji: "New Show", english: null, native: null },
+          coverImage: { large: null, extraLarge: null },
+          status: null,
+          format: MediaFormat.Movie,
+          episodes: 1,
+          seasonYear: 2024,
+          mediaListEntry: null,
+        }}
+      />
+    );
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Set Status");
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "Plan to Watch" }));
+
+    expect(updateStatus).toHaveBeenCalledWith({
+      mediaId: 7,
+      status: MediaListStatus.Planning,
+    });
+  });
+});

--- a/client/src/generated/operations.ts
+++ b/client/src/generated/operations.ts
@@ -23,6 +23,15 @@ export type GetUserMediaListQueryVariables = Exact<{
 
 export type GetUserMediaListQuery = { MediaListCollection: { lists: Array<{ entries: Array<{ id: number, status: Types.MediaListStatus | null, progress: number | null, media: { id: number, status: Types.MediaStatus | null, episodes: number | null, genres: Array<string | null> | null, title: { romaji: string | null, english: string | null, native: string | null } | null, coverImage: { large: string | null, extraLarge: string | null } | null, nextAiringEpisode: { airingAt: number, episode: number } | null, tags: Array<{ name: string, category: string | null } | null> | null, studios: { nodes: Array<{ id: number, name: string } | null> | null } | null } | null } | null> | null } | null> | null } | null };
 
+export type SearchMediaQueryVariables = Exact<{
+  search: string;
+  page: number;
+  perPage: number;
+}>;
+
+
+export type SearchMediaQuery = { Page: { pageInfo: { currentPage: number | null, hasNextPage: boolean | null, perPage: number | null, total: number | null } | null, media: Array<{ id: number, status: Types.MediaStatus | null, format: Types.MediaFormat | null, episodes: number | null, seasonYear: number | null, title: { romaji: string | null, english: string | null, native: string | null } | null, coverImage: { large: string | null, extraLarge: string | null } | null, mediaListEntry: { id: number, status: Types.MediaListStatus | null, progress: number | null } | null } | null> | null } | null };
+
 export type UpdateMediaListProgressMutationVariables = Exact<{
   mediaId: number;
   progress: number | null | undefined;

--- a/client/src/generated/types.ts
+++ b/client/src/generated/types.ts
@@ -1718,6 +1718,8 @@ export enum MediaRelation {
   Parent = 'PARENT',
   /** Released before the relation */
   Prequel = 'PREQUEL',
+  /** Version 3 only. The media is set in the same universe as another media */
+  SameUniverse = 'SAME_UNIVERSE',
   /** Released after the relation */
   Sequel = 'SEQUEL',
   /** A side story of the parent media */

--- a/client/src/lib/__tests__/anilist-search.test.ts
+++ b/client/src/lib/__tests__/anilist-search.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MediaListStatus } from "@/generated/graphql";
+
+const queryAniList = vi.fn();
+
+vi.mock("../anilistProxy", () => ({
+  queryAniList: (...args: unknown[]) => queryAniList(...args),
+}));
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("searchAnime", () => {
+  beforeEach(() => {
+    queryAniList.mockReset();
+  });
+
+  it("returns empty results for blank search without calling the proxy", async () => {
+    const { searchAnime } = await import("../anilist");
+
+    await expect(searchAnime("   ")).resolves.toEqual({
+      media: [],
+      pageInfo: null,
+    });
+    expect(queryAniList).not.toHaveBeenCalled();
+  });
+
+  it("queries AniList and returns media with list status", async () => {
+    const { searchAnime } = await import("../anilist");
+
+    queryAniList.mockResolvedValue({
+      data: {
+        Page: {
+          pageInfo: {
+            currentPage: 1,
+            hasNextPage: false,
+            perPage: 20,
+            total: 1,
+          },
+          media: [
+            {
+              id: 21,
+              title: { romaji: "One Piece", english: "One Piece", native: null },
+              coverImage: { large: "https://example.com/op.jpg", extraLarge: null },
+              status: "RELEASING",
+              format: "TV",
+              episodes: null,
+              seasonYear: 1999,
+              mediaListEntry: {
+                id: 9,
+                status: MediaListStatus.Current,
+                progress: 1100,
+              },
+            },
+            null,
+          ],
+        },
+      },
+    });
+
+    const result = await searchAnime("one piece", 1, 20);
+
+    expect(queryAniList).toHaveBeenCalledWith(
+      expect.stringContaining("SearchMedia"),
+      { search: "one piece", page: 1, perPage: 20 }
+    );
+    expect(result.media).toHaveLength(1);
+    expect(result.media[0]?.id).toBe(21);
+    expect(result.media[0]?.mediaListEntry?.status).toBe(MediaListStatus.Current);
+    expect(result.pageInfo?.total).toBe(1);
+  });
+});

--- a/client/src/lib/anilist.ts
+++ b/client/src/lib/anilist.ts
@@ -5,10 +5,29 @@ import {
   GetUserMediaListQuery,
   MediaFragmentFragment,
   MediaListStatus,
+  SearchMediaQuery,
 } from "@/generated/graphql";
-import { GET_USER_MEDIA_LIST_QUERY, GET_MEDIA_QUERY } from "@/queries/queries";
+import {
+  GET_USER_MEDIA_LIST_QUERY,
+  GET_MEDIA_QUERY,
+  SEARCH_MEDIA_QUERY,
+} from "@/queries/queries";
 import { queryAniList } from "./anilistProxy";
 import { logger } from "./logger";
+
+export type SearchMediaResult = NonNullable<
+  NonNullable<SearchMediaQuery["Page"]>["media"]
+>[number];
+
+export interface SearchMediaPage {
+  media: SearchMediaResult[];
+  pageInfo: {
+    currentPage: number | null;
+    hasNextPage: boolean | null;
+    perPage: number | null;
+    total: number | null;
+  } | null;
+}
 
 const ANILIST_GRAPHQL_URL = "https://graphql.anilist.co";
 
@@ -98,6 +117,45 @@ export async function fetchAuthenticatedAnimeDetails(
     return media;
   } catch (error) {
     logger.error("Error fetching authenticated anime details:", error);
+    throw error;
+  }
+}
+
+const DEFAULT_SEARCH_PER_PAGE = 20;
+
+/**
+ * Searches AniList anime via the authenticated proxy so results include
+ * the current user's mediaListEntry for status changes.
+ */
+export async function searchAnime(
+  search: string,
+  page = 1,
+  perPage = DEFAULT_SEARCH_PER_PAGE
+): Promise<SearchMediaPage> {
+  const trimmed = search.trim();
+  if (!trimmed) {
+    return { media: [], pageInfo: null };
+  }
+
+  try {
+    const response = await queryAniList<SearchMediaQuery>(SEARCH_MEDIA_QUERY, {
+      search: trimmed,
+      page,
+      perPage,
+    });
+
+    const pageData = response.data?.Page;
+    const media =
+      pageData?.media?.filter(
+        (item): item is SearchMediaResult => item !== null
+      ) ?? [];
+
+    return {
+      media,
+      pageInfo: pageData?.pageInfo ?? null,
+    };
+  } catch (error) {
+    logger.error("Error searching anime:", error);
     throw error;
   }
 }

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -6,4 +6,6 @@ export const queryKeys = {
     ["/anilist/anime", "list", userId, [...status].sort().join(",")] as const,
   animeDetail: (mediaId: number) =>
     ["/anilist/anime", "detail", mediaId] as const,
+  animeSearch: (search: string, page: number) =>
+    ["/anilist/anime", "search", search, page] as const,
 };

--- a/client/src/lib/queryKeys.ts
+++ b/client/src/lib/queryKeys.ts
@@ -6,6 +6,6 @@ export const queryKeys = {
     ["/anilist/anime", "list", userId, [...status].sort().join(",")] as const,
   animeDetail: (mediaId: number) =>
     ["/anilist/anime", "detail", mediaId] as const,
-  animeSearch: (search: string, page: number) =>
-    ["/anilist/anime", "search", search, page] as const,
+  animeSearch: (search: string) =>
+    ["/anilist/anime", "search", search] as const,
 };

--- a/client/src/pages/__tests__/search.test.tsx
+++ b/client/src/pages/__tests__/search.test.tsx
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MediaFormat, MediaListStatus } from "@/generated/graphql";
+import SearchPage from "../search";
+
+const searchAnime = vi.fn();
+
+vi.mock("@/lib/anilist", () => ({
+  searchAnime: (...args: unknown[]) => searchAnime(...args),
+}));
+
+vi.mock("@/hooks/useUpdateStatus", () => ({
+  useUpdateStatus: () => ({
+    updateStatus: vi.fn(),
+    isUpdating: false,
+  }),
+}));
+
+function renderSearchPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <SearchPage />
+    </QueryClientProvider>
+  );
+}
+
+describe("SearchPage", () => {
+  beforeEach(() => {
+    searchAnime.mockReset();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears results immediately when the search input is emptied", async () => {
+    searchAnime.mockResolvedValue({
+      media: [
+        {
+          id: 1,
+          title: { romaji: "Naruto", english: "Naruto", native: null },
+          coverImage: { large: null, extraLarge: null },
+          status: null,
+          format: MediaFormat.Tv,
+          episodes: 220,
+          seasonYear: 2002,
+          mediaListEntry: {
+            id: 1,
+            status: MediaListStatus.Completed,
+            progress: 220,
+          },
+        },
+      ],
+      pageInfo: {
+        currentPage: 1,
+        hasNextPage: false,
+        perPage: 20,
+        total: 1,
+      },
+    });
+
+    renderSearchPage();
+
+    const input = screen.getByPlaceholderText("Search anime...");
+    fireEvent.change(input, { target: { value: "naruto" } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Naruto")).toBeInTheDocument();
+    });
+
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(screen.queryByText("Naruto")).not.toBeInTheDocument();
+    expect(screen.queryByText(/result/i)).not.toBeInTheDocument();
+  });
+
+  it("loads additional pages when Load more is pressed", async () => {
+    searchAnime
+      .mockResolvedValueOnce({
+        media: [
+          {
+            id: 1,
+            title: { romaji: "Show One", english: null, native: null },
+            coverImage: { large: null, extraLarge: null },
+            status: null,
+            format: MediaFormat.Tv,
+            episodes: 12,
+            seasonYear: 2020,
+            mediaListEntry: null,
+          },
+        ],
+        pageInfo: {
+          currentPage: 1,
+          hasNextPage: true,
+          perPage: 20,
+          total: 40,
+        },
+      })
+      .mockResolvedValueOnce({
+        media: [
+          {
+            id: 2,
+            title: { romaji: "Show Two", english: null, native: null },
+            coverImage: { large: null, extraLarge: null },
+            status: null,
+            format: MediaFormat.Movie,
+            episodes: 1,
+            seasonYear: 2021,
+            mediaListEntry: null,
+          },
+        ],
+        pageInfo: {
+          currentPage: 2,
+          hasNextPage: false,
+          perPage: 20,
+          total: 40,
+        },
+      });
+
+    renderSearchPage();
+
+    fireEvent.change(screen.getByPlaceholderText("Search anime..."), {
+      target: { value: "show" },
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Show One")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Show Two")).toBeInTheDocument();
+    });
+
+    expect(searchAnime).toHaveBeenNthCalledWith(1, "show", 1);
+    expect(searchAnime).toHaveBeenNthCalledWith(2, "show", 2);
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+  });
+
+  it("shows a controlled error message instead of transport details", async () => {
+    vi.useRealTimers();
+    searchAnime.mockRejectedValue(new Error("GraphQL error: Internal server error"));
+
+    renderSearchPage();
+
+    fireEvent.change(screen.getByPlaceholderText("Search anime..."), {
+      target: { value: "fail" },
+    });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByText("Failed to search anime. Please try again.")
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+    expect(screen.queryByText(/GraphQL error/i)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { SearchBar } from "@/components/home/SearchBar";
+import { SearchResultRow } from "@/components/search/SearchResultRow";
+import { useDebounce } from "@/hooks/useDebounce";
+import { searchAnime } from "@/lib/anilist";
+import { commonQueryOptions } from "@/lib/query-config";
+import { queryKeys } from "@/lib/queryKeys";
+import { Loader2 } from "lucide-react";
+
+export default function SearchPage() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+  const trimmedQuery = debouncedSearchQuery.trim();
+  const isDebouncing =
+    searchQuery.trim() !== trimmedQuery && searchQuery.trim() !== "";
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: queryKeys.animeSearch(trimmedQuery, 1),
+    queryFn: () => searchAnime(trimmedQuery, 1),
+    enabled: trimmedQuery.length > 0,
+    ...commonQueryOptions,
+  });
+
+  const results = data?.media ?? [];
+  const totalResults =
+    trimmedQuery.length === 0
+      ? null
+      : (data?.pageInfo?.total ?? (isLoading || isDebouncing ? null : results.length));
+  const showLoading = isDebouncing || (trimmedQuery.length > 0 && (isLoading || isFetching));
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 px-4 sm:px-6 lg:px-10">
+      <h1 className="text-2xl font-semibold tracking-tight">Search</h1>
+
+      <SearchBar
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        totalResults={totalResults}
+        isLoading={showLoading}
+      />
+
+      <div className="pt-2">
+        {trimmedQuery.length === 0 ? null : error ? (
+          <p className="text-sm text-destructive">
+            {error instanceof Error
+              ? error.message
+              : "Failed to search anime. Please try again."}
+          </p>
+        ) : isLoading || isDebouncing ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : results.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No results found.</p>
+        ) : (
+          <div>
+            {results.map((media) =>
+              media ? <SearchResultRow key={media.id} media={media} /> : null
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/search.tsx
+++ b/client/src/pages/search.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { SearchBar } from "@/components/home/SearchBar";
 import { SearchResultRow } from "@/components/search/SearchResultRow";
+import { Button } from "@/components/ui/button";
 import { useDebounce } from "@/hooks/useDebounce";
 import { searchAnime } from "@/lib/anilist";
 import { commonQueryOptions } from "@/lib/query-config";
@@ -10,29 +11,44 @@ import { Loader2 } from "lucide-react";
 
 export default function SearchPage() {
   const [searchQuery, setSearchQuery] = useState("");
-  const debouncedSearchQuery = useDebounce(searchQuery, 300);
-  const trimmedQuery = debouncedSearchQuery.trim();
-  const isDebouncing =
-    searchQuery.trim() !== trimmedQuery && searchQuery.trim() !== "";
+  const liveQuery = searchQuery.trim();
+  // Clear immediately when the input is empty so stale results don't linger
+  // for the debounce window.
+  const debouncedSearchQuery = useDebounce(liveQuery, 300);
+  const trimmedQuery = liveQuery.length === 0 ? "" : debouncedSearchQuery;
+  const isDebouncing = liveQuery.length > 0 && liveQuery !== trimmedQuery;
 
   const {
     data,
     isLoading,
     isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
     error,
-  } = useQuery({
-    queryKey: queryKeys.animeSearch(trimmedQuery, 1),
-    queryFn: () => searchAnime(trimmedQuery, 1),
+  } = useInfiniteQuery({
+    queryKey: queryKeys.animeSearch(trimmedQuery),
+    queryFn: ({ pageParam }) => searchAnime(trimmedQuery, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.pageInfo?.hasNextPage) {
+        return undefined;
+      }
+      return (lastPage.pageInfo.currentPage ?? 1) + 1;
+    },
     enabled: trimmedQuery.length > 0,
     ...commonQueryOptions,
   });
 
-  const results = data?.media ?? [];
+  const results = data?.pages.flatMap((page) => page.media) ?? [];
   const totalResults =
-    trimmedQuery.length === 0
+    liveQuery.length === 0
       ? null
-      : (data?.pageInfo?.total ?? (isLoading || isDebouncing ? null : results.length));
-  const showLoading = isDebouncing || (trimmedQuery.length > 0 && (isLoading || isFetching));
+      : (data?.pages[0]?.pageInfo?.total ??
+        (isLoading || isDebouncing ? null : results.length));
+  const showSpinnerInBar =
+    isDebouncing ||
+    (trimmedQuery.length > 0 && isFetching && !isFetchingNextPage);
 
   return (
     <div className="mx-auto w-full max-w-3xl space-y-6 px-4 sm:px-6 lg:px-10">
@@ -42,15 +58,13 @@ export default function SearchPage() {
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
         totalResults={totalResults}
-        isLoading={showLoading}
+        isLoading={showSpinnerInBar}
       />
 
       <div className="pt-2">
-        {trimmedQuery.length === 0 ? null : error ? (
+        {liveQuery.length === 0 ? null : error ? (
           <p className="text-sm text-destructive">
-            {error instanceof Error
-              ? error.message
-              : "Failed to search anime. Please try again."}
+            Failed to search anime. Please try again.
           </p>
         ) : isLoading || isDebouncing ? (
           <div className="flex items-center justify-center py-12">
@@ -63,6 +77,26 @@ export default function SearchPage() {
             {results.map((media) =>
               media ? <SearchResultRow key={media.id} media={media} /> : null
             )}
+            {hasNextPage ? (
+              <div className="flex justify-center pt-4">
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    void fetchNextPage();
+                  }}
+                  disabled={isFetchingNextPage}
+                >
+                  {isFetchingNextPage ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Loading
+                    </>
+                  ) : (
+                    "Load more"
+                  )}
+                </Button>
+              </div>
+            ) : null}
           </div>
         )}
       </div>

--- a/client/src/queries/queries.ts
+++ b/client/src/queries/queries.ts
@@ -188,3 +188,37 @@ export const UPDATE_STATUS_MUTATION = gql`
     }
   }
 `;
+
+export const SEARCH_MEDIA_QUERY = gql`
+  query SearchMedia($search: String!, $page: Int!, $perPage: Int!) {
+    Page(page: $page, perPage: $perPage) {
+      pageInfo {
+        currentPage
+        hasNextPage
+        perPage
+        total
+      }
+      media(search: $search, type: ANIME, sort: SEARCH_MATCH) {
+        id
+        title {
+          romaji
+          english
+          native
+        }
+        coverImage {
+          large
+          extraLarge
+        }
+        status
+        format
+        episodes
+        seasonYear
+        mediaListEntry {
+          id
+          status
+          progress
+        }
+      }
+    }
+  }
+`;

--- a/client/src/queries/searchMedia.graphql
+++ b/client/src/queries/searchMedia.graphql
@@ -1,0 +1,31 @@
+query SearchMedia($search: String!, $page: Int!, $perPage: Int!) {
+  Page(page: $page, perPage: $perPage) {
+    pageInfo {
+      currentPage
+      hasNextPage
+      perPage
+      total
+    }
+    media(search: $search, type: ANIME, sort: SEARCH_MATCH) {
+      id
+      title {
+        romaji
+        english
+        native
+      }
+      coverImage {
+        large
+        extraLarge
+      }
+      status
+      format
+      episodes
+      seasonYear
+      mediaListEntry {
+        id
+        status
+        progress
+      }
+    }
+  }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -1968,7 +1968,7 @@ type MediaEdge {
 
   """The type of relation to the parent model"""
   relationType(
-    """Provide 2 to use new version 2 of relation enum"""
+    """Provide 3 to use new version 3 of relation enum"""
     version: Int
   ): MediaRelation
 
@@ -2370,6 +2370,9 @@ enum MediaRelation {
 
   """Released before the relation"""
   PREQUEL
+
+  """Version 3 only. The media is set in the same universe as another media"""
+  SAME_UNIVERSE
 
   """Released after the relation"""
   SEQUEL


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a protected `/search` page (nav: Search) that queries AniList anime by title through the authenticated proxy
- Each result shows cover, title, format/year, and a status selector so you can set or change watch status (Watching, Plan to Watch, Completed, etc.) without opening the show page
- Reuses existing `StatusSelector` / `SaveMediaListEntry` mutation; search results invalidate with other anime queries after updates

## Review fixes
- Clear results immediately when the search input is emptied (no stale debounce window)
- Paginate beyond the first 20 results with a Load more control (`useInfiniteQuery`)
- Show a controlled user-facing error instead of raw proxy/GraphQL messages

## Test plan
- [x] `yarn run check` (tsc)
- [x] `yarn test` (103 tests)
- [ ] Manually: open Search, type a title, change status on a result, confirm toast + Home/list reflect the new status
- [ ] Manually: clear the search field and confirm results disappear immediately
- [ ] Manually: search a broad term and use Load more when available
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fca9e-d6f0-726c-91d0-67123bad2658?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fca9e-d6f0-726c-91d0-67123bad2658&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

