### PR TITLE
Fix mobile tab bar floating mid-scroll

### DIFF
--- a/client/src/components/__tests__/layout.test.tsx
+++ b/client/src/components/__tests__/layout.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+import { Layout } from "../layout";
+
+vi.mock("@/lib/auth", () => ({
+  logout: vi.fn(),
+}));
+
+vi.mock("@/components/theme-toggle", () => ({
+  ThemeToggle: () => <button type="button">Theme</button>,
+}));
+
+describe("Layout", () => {
+  it("docks the mobile tab bar outside the scrolling main region", () => {
+    const { hook } = memoryLocation({ path: "/", static: true });
+
+    const { container } = render(
+      <Router hook={hook}>
+        <Layout>
+          <div>Page content</div>
+        </Layout>
+      </Router>,
+    );
+
+    const shell = container.firstElementChild as HTMLElement;
+    expect(shell.className).toContain("h-dvh");
+    expect(shell.className).toContain("flex-col");
+    expect(shell.className).toContain("overflow-hidden");
+
+    const main = container.querySelector("main");
+    expect(main).not.toBeNull();
+    expect(main?.className).toContain("overflow-y-auto");
+    expect(main?.className).toContain("flex-1");
+    expect(main).toHaveTextContent("Page content");
+
+    const tabBar = screen.getByRole("navigation", { name: "Primary" });
+    expect(tabBar.className).not.toContain("fixed");
+    expect(tabBar.className).toContain("shrink-0");
+    expect(main?.compareDocumentPosition(tabBar) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    expect(
+      tabBar.querySelectorAll("a").length,
+    ).toBe(4);
+    expect(tabBar).toHaveTextContent("Home");
+    expect(tabBar).toHaveTextContent("Search");
+    expect(tabBar).toHaveTextContent("Calendar");
+    expect(tabBar).toHaveTextContent("Profile");
+  });
+});

--- a/client/src/components/layout.tsx
+++ b/client/src/components/layout.tsx
@@ -28,7 +28,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex h-dvh flex-col overflow-hidden bg-background md:h-auto md:min-h-screen md:overflow-visible">
       <nav className="fixed top-0 left-0 right-0 z-50 hidden h-16 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 md:block">
         <div className="mx-auto flex h-full w-full items-center justify-between px-4 sm:px-6 lg:px-10 xl:px-12 2xl:px-16">
           <div className="flex items-center gap-6">
@@ -56,8 +56,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         </div>
       </nav>
 
+      <main className="min-h-0 w-full flex-1 overflow-y-auto overscroll-y-contain pt-[calc(1rem_+_env(safe-area-inset-top))] md:overflow-visible md:overscroll-auto md:pb-8 md:pt-20">
+        {children}
+      </main>
+
       <nav
-        className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur supports-[backdrop-filter]:bg-background/60 md:hidden"
+        className="shrink-0 border-t bg-background pb-[env(safe-area-inset-bottom)] md:hidden"
         aria-label="Primary"
       >
         <div className="grid h-16 grid-cols-4">
@@ -82,10 +86,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
           })}
         </div>
       </nav>
-
-      <main className="w-full pb-[calc(5.5rem_+_env(safe-area-inset-bottom))] pt-[calc(1rem_+_env(safe-area-inset-top))] md:pb-8 md:pt-20">
-        {children}
-      </main>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On mobile Safari/PWA, the bottom tab bar could appear stuck mid-screen while scrolling (content visible above and below it).

Root cause: the bar used `position: fixed; bottom: 0` against a document that scrolled with `min-h-screen` (`100vh`). iOS visual-viewport changes during scroll make that combination misplace the bar; `backdrop-blur` on the fixed layer made the lag more noticeable.

## Fix
Dock the tab bar in normal layout flow inside a mobile `h-dvh` flex column:
- shell: `flex h-dvh flex-col overflow-hidden` (desktop keeps growing/`min-h-screen`)
- `main`: `flex-1 min-h-0 overflow-y-auto` — only content scrolls
- bottom nav: `shrink-0` sibling (not `fixed`), with safe-area padding kept

Desktop top nav behavior is unchanged.

## Test plan
- [ ] On iPhone Safari (or installed PWA), open Home and fling-scroll the list — tab bar stays pinned to the bottom
- [ ] Confirm Home / Search / Calendar / Profile tabs still navigate
- [ ] Confirm content is not hidden behind the tab bar (no extra bottom spacer needed)
- [ ] Desktop (`md+`): top nav still works; no bottom tab bar
- [x] `yarn run check` / `yarn test` (104 tests, including new layout docking assertion)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe6e3-da1e-7d10-8d8c-586ff7207ea9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe6e3-da1e-7d10-8d8c-586ff7207ea9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

